### PR TITLE
Specify sadist-ci repo explicitly,

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
     # Checks-out sadist-ci under $GITHUB_WORKSPACE
     - uses: actions/checkout@v2
+      with:
+        repository: ilyaukin/sadist-ci
+        token: ${{ secrets.ACCESS_TOKEN }}
 
     # Sets up docker certificates
     - name: Dump secrets


### PR DESCRIPTION
because this workflow may be called from the other repo.